### PR TITLE
client: improved error handling

### DIFF
--- a/.github/workflows/on_pr_push.yml
+++ b/.github/workflows/on_pr_push.yml
@@ -1,0 +1,27 @@
+name: On push
+on: 
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  test:
+    name: Test on Ubuntu
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        go: ['1.12', '1.13', '1.14']
+
+    steps:
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+      id: go
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Run tests
+      run: go test -mod vendor ./... 

--- a/client/error.go
+++ b/client/error.go
@@ -2,7 +2,10 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 )
+
+var ErrNotFound = errors.New("resource not found")
 
 type Error struct {
 	Msg string `json:"error"`

--- a/cmd/scoutred-lambda/env.go
+++ b/cmd/scoutred-lambda/env.go
@@ -33,7 +33,7 @@ func (env *Env) Read() error {
 	}
 	env.CSVLatIdx, err = strconv.ParseUint(latIdx, 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid value for CSV_LAT_IDX: %d : %v", latIdx, err)
+		return fmt.Errorf("invalid value for CSV_LAT_IDX: %s : %v", latIdx, err)
 	}
 
 	lonIdx := os.Getenv("CSV_LON_IDX")
@@ -42,7 +42,7 @@ func (env *Env) Read() error {
 	}
 	env.CSVLonIdx, err = strconv.ParseUint(lonIdx, 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid value for CSV_LON_IDX: %d : %v", lonIdx, err)
+		return fmt.Errorf("invalid value for CSV_LON_IDX: %s : %v", lonIdx, err)
 	}
 
 	env.DestS3Bucket = os.Getenv("DESTINATION_S3_BUCKET")


### PR DESCRIPTION
Some errors returned by the server are not in JSON. This commit has the
client try to unmarshal the erroneous (non 200) response or fall back to
just using the body as its Msg.