### PR TITLE
cmd/scoutred/cmd: prune unused zoningHeader

### DIFF
--- a/cmd/scoutred/cmd/zoning_csv.go
+++ b/cmd/scoutred/cmd/zoning_csv.go
@@ -18,11 +18,6 @@ var (
 	csvAppend bool
 )
 
-// zoningHeader are the additional zoning headers that will be added
-var zoningHeader = []string{
-	"designation",
-}
-
 // csvCmd represents the csv command
 var zoningCsvCmd = &cobra.Command{
 	Use:   "csv",


### PR DESCRIPTION
This drive-by commit drops the unused `zoningHeader` variable.